### PR TITLE
Release/snowplow attribution/0.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+snowplow-attribution 0.2.2 (2024-06-19)
+---------------------------------------
+## Summary
+This release fixes a bug in the source_checks() macro that could fail if the `snowplow__conversions_source` or `snowplow__conversion_path_source` variables are overwritten. This fix should allow users to provide a `schema.table` or `warehouse.schema.table` style string reference for these sources without having to specify a dbt source in their project (similar to the default), if necessary.
+
+## Fixes
+- Fix source checks macro
+
+## Upgrading
+Bump the snowplow-unified version in your `packages.yml` file.
+
 snowplow-attribution 0.2.1 (2024-06-11)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'snowplow_attribution'
-version: '0.2.1'
+version: '0.2.2'
 config-version: 2
 
 require-dbt-version: [">=1.6.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_attribution_integration_tests'
-version: '0.2.1'
+version: '0.2.2'
 config-version: 2
 
 profile: 'integration_tests'

--- a/macros/attribution_overview.sql
+++ b/macros/attribution_overview.sql
@@ -1,3 +1,10 @@
+{#
+Copyright (c) 2024-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
 {% macro attribution_overview() %}
     {{ return(adapter.dispatch('attribution_overview', 'snowplow_attribution')()) }}
 {% endmacro %}

--- a/macros/get_relation_from_string.sql
+++ b/macros/get_relation_from_string.sql
@@ -1,0 +1,42 @@
+{#
+Copyright (c) 2024-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+/*  Macro to allow for hardcoding of the source table reference in var('snowplow__conversion_path_source') 
+and var('snowplow__conversions_source'). */
+
+{% macro get_relation_from_string(full_table_reference) %}
+
+  {% set full_table_reference_without_quotes = full_table_reference | replace("`", "") | replace('"', '') %}
+  {% set parts = full_table_reference_without_quotes.split('.') %}
+  
+  {% if parts | length == 3 %}
+    {% set database = parts[0] %}
+    {% set schema = parts[1] %}
+    {% set table = parts[2] %}
+  
+  {% elif parts | length == 2 %}
+    {% set database = target.database %}
+    {% set schema = parts[0] %}
+    {% set table = parts[1] %}
+    
+  {% else %}
+    {{ exceptions.raise_compiler_error(
+"Snowplow Error: Compilation error within "~full_table_reference ~". Please make sure you provide a valid table reference that includes a schema."
+    ) }}
+  {% endif %}
+
+  {% set relation = adapter.get_relation(
+        database=database,
+        schema=schema,
+        identifier=table
+    ) %}
+    
+  {% if relation %}
+    {{ return(relation) }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/source_checks.sql
+++ b/macros/source_checks.sql
@@ -15,7 +15,7 @@
   {% if is_incremental() %}
     {% if last_cv_tstamp < last_processed_cv_tstamp %}
     {{ exceptions.raise_compiler_error(
-"Snowplow Error: The timestamp of the last conversion event in the conversion souce ("~ var('snowplow__conversions_source',source('derived', 'snowplow_unified_conversions')) ~ "):" ~ last_cv_tstamp ~ 
+"Snowplow Error: The timestamp of the last conversion event in the conversion source ("~ var('snowplow__conversions_source',source('derived', 'snowplow_unified_conversions')) ~ "):" ~ last_cv_tstamp ~ 
     " is lower than the timestamp of the last processed conversion " ~ last_processed_cv_tstamp ~ 
     "within the model "~ this ~ ". Please make sure you have updated downstream sources before proceeding."
     ) }}

--- a/macros/source_checks.sql
+++ b/macros/source_checks.sql
@@ -1,5 +1,4 @@
-/* Returns the last 'snowplow__path_lookback_steps' number of channels in the path if snowplow__path_lookback_steps > 0,
-   or the full path otherwise. */
+/*  Macro to make sure the user does not execute the package with missing conversion or path source data. */
 
 {% macro source_checks() %}
   {{ return(adapter.dispatch('source_checks', 'snowplow_attribution')()) }}
@@ -7,17 +6,19 @@
 
 {% macro default__source_checks() %}
 
-  {%- set __, last_cv_tstamp = snowplow_utils.return_limits_from_model(source('derived', 'snowplow_unified_conversions'),'cv_tstamp','cv_tstamp') %}
-  {%- set __, last_path_tstamp = snowplow_utils.return_limits_from_model(source('derived', 'snowplow_unified_sessions'),'start_tstamp','start_tstamp') %}
+  {% set conversions_source_relation = snowplow_attribution.get_relation_from_string(var('snowplow__conversions_source', '')) | default(source('derived', 'snowplow_unified_conversions')) %}
+  {% set conversion_path_source_relation = snowplow_attribution.get_relation_from_string(var('snowplow__conversion_path_source', '')) | default(source('derived', 'snowplow_unified_views')) %}
+  {%- set __, last_cv_tstamp = snowplow_utils.return_limits_from_model(conversions_source_relation,'cv_tstamp','cv_tstamp') %}
+  {%- set __, last_path_tstamp = snowplow_utils.return_limits_from_model(conversion_path_source_relation,'start_tstamp','start_tstamp') %}
   {%- set __, last_processed_cv_tstamp = snowplow_utils.return_limits_from_model(this,'cv_path_start_tstamp','cv_path_start_tstamp') %}
 
   {% if is_incremental() %}
     {% if last_cv_tstamp < last_processed_cv_tstamp %}
-      {{ exceptions.raise_compiler_error(
-      "Snowplow Error: The timestamp of the last conversion event in the conversion souce: " ~ last_cv_tstamp ~ 
-      " is lower than the timestamp of the last processed conversion " ~ last_processed_cv_tstamp ~ 
-      "within the model snowplow_attribution_paths_to_conversion. Please make sure you have updated downstream sources before proceeding."
-      ) }}
+    {{ exceptions.raise_compiler_error(
+"Snowplow Error: The timestamp of the last conversion event in the conversion souce ("~ var('snowplow__conversions_source',source('derived', 'snowplow_unified_conversions')) ~ "):" ~ last_cv_tstamp ~ 
+    " is lower than the timestamp of the last processed conversion " ~ last_processed_cv_tstamp ~ 
+    "within the model "~ this ~ ". Please make sure you have updated downstream sources before proceeding."
+    ) }}
     {% endif %}
   {% endif %}
   


### PR DESCRIPTION
## Description

This release fixes a bug in the source_checks() macro that could fail if the `snowplow__conversions_source` or `snowplow__conversion_path_source` variables are overwritten. This fix should allow users to provide a `schema.table` or `warehouse.schema.table` style string reference for these sources without having to specify a dbt source in their project (similar to the default), if necessary.


[Release checklist](https://www.notion.so/keep-in-the-snow/5058060fa44841989620e4cd306404ca?v=86817f2dc72942c4aee757a0b6756202&p=0bb0f116829543cfb24e0c51e739e6f6&pm=s)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Checklist
- [x] 🎉 I have verified that these changes work locally
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md
### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [x] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation/pull/935) PR if applicable (Link here if required)
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
## What gif best describes this PR or how it makes you feel?
<img src="https://media1.giphy.com/media/qg7QE182TLxRHERdcJ/giphy.gif"/>


## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have changed the release date in the CHANGELOG.md 

