### PR TITLE
Release/snowplow attribution/0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+snowplow-attribution 0.3.0 (2024-07-26)
+---------------------------------------
+## Summary
+This release introduces a new user stitching logic when the `snowplow__conversion_stitching` variable is not enabled to avoid the need of having to enable both view and conversion stitching in the unified package to get the most accurate user journeys and conversions. The package will rely on one more source from the Unified Digital dbt package, the `snowplow_unified_user_mapping` table to accomplish this.
+
+## Features
+Change stitching logic
+
+## Upgrading
+Bump the snowplow-attribution version in your `packages.yml` file.
+
+## 🚨 Breaking Changes 🚨
+Due to the new user mapping table join in the paths_to_conversions() macro it may be that your `snowplow__conversion_clause` variable would need to be changed by adding the `ev` table alias to the fields it references (for user_identifier or user_id).
+
+The package by default will now rely on the `snowplow_unified_user_mapping` table. Although most users would use the Unified package as a source already (therefore this should not be a breaking change), for those users where it is not available, the `paths_to_conversion()` macro will have to be overwritten in the dbt project where the package is referenced. Similarly, the optional `paths_to_non_conversion` model is also changed, it would need to be disabled and overwritten in that case, too.
+
 snowplow-attribution 0.2.2 (2024-06-19)
 ---------------------------------------
 ## Summary
@@ -7,7 +23,7 @@ This release fixes a bug in the source_checks() macro that could fail if the `sn
 - Fix source checks macro
 
 ## Upgrading
-Bump the snowplow-unified version in your `packages.yml` file.
+Bump the snowplow-attribution version in your `packages.yml` file.
 
 snowplow-attribution 0.2.1 (2024-06-11)
 ---------------------------------------
@@ -21,7 +37,7 @@ This release removes null user_identifier data when the conversions_source and p
 - Add Redshift to tests
 
 ## Upgrading
-Bump the snowplow-unified version in your `packages.yml` file.
+Bump the snowplow-attribution version in your `packages.yml` file.
 
 snowplow-attribution 0.2.0 (2024-03-26)
 ---------------------------------------

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -38,9 +38,10 @@ vars:
     snowplow__campaigns_to_include: [] # Optional filter on which campaigns to include when creating paths e.g. ['UK Snowplow September']
     snowplow__conversion_path_source: "{{ source('derived', 'snowplow_unified_views')}}"
     snowplow__conversions_source: "{{ source('derived', 'snowplow_unified_conversions') }}"
+    snowplow__user_mapping_source: "{{ source('derived', 'snowplow_unified_user_mapping') }}"
     snowplow__spend_source: 'not defined' # Optional, needed for the ROAS calculation of the snowplow_attribution.overview. Should be changed to a table reference with 'spend' by 'channel' and/or 'campaign' by 'spend_tstamp' (which denotes a timestamp field) information
-    snowplow__conversion_stitching: false
-    snowplow__conversion_clause: 'cv_value > 0 and user_identifier is not null'
+    snowplow__conversion_stitching: false # When true the view events will be joined to the conversion event based on stitched_user_id. Both conversion and view stitching needs to be enabled in the unified model for it to work properly.
+    snowplow__conversion_clause: 'cv_value > 0 and ev.user_identifier is not null'
     
     # Variables that change the drop and recompute report tables only
     snowplow__conversion_window_start_date: '' # an explicit conversion window start date overwrite

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'snowplow_attribution'
-version: '0.2.2'
+version: '0.3.0'
 config-version: 2
 
 require-dbt-version: [">=1.6.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_attribution_integration_tests'
-version: '0.2.2'
+version: '0.3.0'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -14,6 +14,7 @@ sources:
         description: An incremental table which contains all relevant fields for unique conversion events.
       - name: snowplow_unified_views 
       - name: snowplow_unified_sessions
+      - name: snowplow_unified_user_mapping
 
 models:
   - name: snowplow_attribution_path_summary


### PR DESCRIPTION
## Description
This release introduces a new user stitching logic when the `snowplow__conversion_stitching` variable is not enabled to avoid the need of having to enable both view and conversion stitching in the unified package to get the most accurate user journeys and conversions. The package will rely on one more source from the Unified Digital dbt package, the `snowplow_unified_user_mapping` table to accomplish this.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
https://www.notion.so/keep-in-the-snow/5058060fa44841989620e4cd306404ca?v=86817f2dc72942c4aee757a0b6756202&p=0082c163780e4f3fb5179c60112daa74&pm=s

## Checklist
- [x] 🎉 I have verified that these changes work locally
- [x] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md
### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [x] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation/pull/963 and https://github.com/snowplow/documentation/pull/965/files) PR if applicable 
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
<img src="https://media3.giphy.com/media/3w9lAzgwdhC34K4fLx/giphy.gif"/>

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have changed the release date in the CHANGELOG.md 

